### PR TITLE
Step 2: Add InboundWebhook model for storing webhooks

### DIFF
--- a/app/controllers/webhooks/base_controller.rb
+++ b/app/controllers/webhooks/base_controller.rb
@@ -3,6 +3,13 @@ class Webhooks::BaseController < ApplicationController
   skip_before_action :verify_authenticity_token
 
   def create
+    InboundWebhook.create(body: payload)
     head :ok
+  end
+
+  private
+
+  def payload
+    @payload ||= request.body.read
   end
 end

--- a/app/models/inbound_webhook.rb
+++ b/app/models/inbound_webhook.rb
@@ -1,0 +1,2 @@
+class InboundWebhook < ApplicationRecord
+end

--- a/db/migrate/20230422190352_create_inbound_webhooks.rb
+++ b/db/migrate/20230422190352_create_inbound_webhooks.rb
@@ -1,0 +1,10 @@
+class CreateInboundWebhooks < ActiveRecord::Migration[7.0]
+  def change
+    create_table :inbound_webhooks do |t|
+      t.string :status
+      t.text :body
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,21 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema[7.0].define(version: 2023_04_22_190352) do
+  create_table "inbound_webhooks", force: :cascade do |t|
+    t.string "status"
+    t.text "body"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+end

--- a/test/fixtures/inbound_webhooks.yml
+++ b/test/fixtures/inbound_webhooks.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  status: MyString
+  body: MyText
+
+two:
+  status: MyString
+  body: MyText

--- a/test/models/inbound_webhook_test.rb
+++ b/test/models/inbound_webhook_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class InboundWebhookTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
This model will be responsible for storing the inbound webhook until a background job can process it.

The reason we want to do this is because we want our controller to respond as fast as possible for heavy traffic (like Black Friday for example) and we want to store the record in the database to safely store it for retries if the service is having trouble for any reason.

Coauthored by @excid3