### PR TITLE
Step 3: Create background jobs for webhook processing

### DIFF
--- a/app/controllers/webhooks/movies_controller.rb
+++ b/app/controllers/webhooks/movies_controller.rb
@@ -7,8 +7,19 @@ class Webhooks::MoviesController < Webhooks::BaseController
   #     -H 'Content-Type: application/json'
   #     -d '{"title":"Dungeons & Dragons: Honor Among Thieves"}'
   #  
-  # If you'd like to override the base controller's behavior, you can do so here
-  # def create
-  #   head :ok
-  # end
+  def create
+    # Save webhook to database
+    record = InboundWebhook.create!(body: payload)
+
+    # Queue database record for processing
+    Webhooks::MoviesJob.perform_later(record)
+
+    head :ok
+  end
+
+  private
+
+  def payload
+    @payload ||= request.body.read
+  end
 end

--- a/app/controllers/webhooks/stripe_controller.rb
+++ b/app/controllers/webhooks/stripe_controller.rb
@@ -1,6 +1,18 @@
 class Webhooks::StripeController < Webhooks::BaseController
-  # If you'd like to override the base controller's behavior, you can do so here
-  # def create
-  #   head :ok
-  # end
+  def create
+    # Save webhook to database
+    record = InboundWebhook.create!(body: payload)
+
+    # Queue database record for processing
+    Webhooks::StripeJob.perform_later(record)
+
+    # Tell Stripe everything was successful
+    head :ok
+  end
+
+  private
+
+  def payload
+    @payload ||= request.body.read
+  end
 end

--- a/app/jobs/webhooks/movies_job.rb
+++ b/app/jobs/webhooks/movies_job.rb
@@ -5,5 +5,7 @@ class Webhooks::MoviesJob < ApplicationJob
     webhook_payload = JSON.parse(inbound_webhook.body, symbolize_names: true)
     # do whatever you'd like here with your webhook payload
     # call another service, update a record, etc.
+
+    inbound_webhook.update!(status: :processed)
   end
 end

--- a/app/jobs/webhooks/movies_job.rb
+++ b/app/jobs/webhooks/movies_job.rb
@@ -1,0 +1,9 @@
+class Webhooks::MoviesJob < ApplicationJob
+  queue_as :default
+
+  def perform(inbound_webhook)
+    webhook_payload = JSON.parse(inbound_webhook.body, symbolize_names: true)
+    # do whatever you'd like here with your webhook payload
+    # call another service, update a record, etc.
+  end
+end

--- a/app/jobs/webhooks/stripe_job.rb
+++ b/app/jobs/webhooks/stripe_job.rb
@@ -1,0 +1,12 @@
+class Webhooks::StripeJob < ApplicationJob
+  queue_as :default
+
+  def perform(inbound_webhook)
+    json = JSON.parse(inbound_webhook.body, symbolize_names: true)
+    event = Stripe::Event.construct_from(json)
+    case event.type
+    when 'customer.updated'
+      # Find customer and save changes
+    end
+  end
+end

--- a/app/jobs/webhooks/stripe_job.rb
+++ b/app/jobs/webhooks/stripe_job.rb
@@ -7,6 +7,9 @@ class Webhooks::StripeJob < ApplicationJob
     case event.type
     when 'customer.updated'
       # Find customer and save changes
+      inbound_webhook.update!(status: :processed)
+    else
+      inbound_webhook.update!(status: :skipped)
     end
   end
 end

--- a/test/jobs/webhooks/movies_job_test.rb
+++ b/test/jobs/webhooks/movies_job_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class Webhooks::MoviesJobTest < ActiveJob::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/jobs/webhooks/stripe_job_test.rb
+++ b/test/jobs/webhooks/stripe_job_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class Webhooks::StripeJobTest < ActiveJob::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
This background job will receive the InboundWebhook record and can process the different types of webhooks.

Coauthored by @excid3