### PR TITLE
Step 4: Webhook Verification

### DIFF
--- a/app/controllers/webhooks/base_controller.rb
+++ b/app/controllers/webhooks/base_controller.rb
@@ -1,6 +1,8 @@
 class Webhooks::BaseController < ApplicationController
   # Disable CSRF checking on webhooks because they do not originate from the browser
   skip_before_action :verify_authenticity_token
+  
+  before_action :verify_event
 
   def create
     InboundWebhook.create(body: payload)
@@ -8,6 +10,10 @@ class Webhooks::BaseController < ApplicationController
   end
 
   private
+
+  def verify_event
+    head :bad_request
+  end
 
   def payload
     @payload ||= request.body.read

--- a/app/controllers/webhooks/movies_controller.rb
+++ b/app/controllers/webhooks/movies_controller.rb
@@ -1,12 +1,14 @@
 class Webhooks::MoviesController < Webhooks::BaseController
-    # A controller for catching new movie webhooks
+  # A controller for catching new movie webhooks
   #
   # To send a sample webhook locally:
   #
   #   curl -X POST http://localhost:3000/webhooks/movies
   #     -H 'Content-Type: application/json'
   #     -d '{"title":"Dungeons & Dragons: Honor Among Thieves"}'
-  #  
+  #
+  # Pass ?fail_verification=1 to simulate a webhook verification failure
+
   def create
     # Save webhook to database
     record = InboundWebhook.create!(body: payload)
@@ -18,6 +20,11 @@ class Webhooks::MoviesController < Webhooks::BaseController
   end
 
   private
+
+  # Pass ?fail_verification=1 to simulate a webhook verification failure
+  def verify_event
+    head :bad_request if params[:fail_verification]
+  end
 
   def payload
     @payload ||= request.body.read

--- a/app/controllers/webhooks/stripe_controller.rb
+++ b/app/controllers/webhooks/stripe_controller.rb
@@ -12,6 +12,21 @@ class Webhooks::StripeController < Webhooks::BaseController
 
   private
 
+  # Verifies the event came from Stripe
+  def verify_event
+    signature = request.headers['Stripe-Signature']
+    secret = Rails.application.credentials.dig(:stripe, :webhook_signing_secret)
+
+    ::Stripe::Webhook::Signature.verify_header(
+      payload,
+      signature,
+      secret.to_s,
+      tolerance: Stripe::Webhook::DEFAULT_TOLERANCE,
+    )
+  rescue ::Stripe::SignatureVerificationError
+    head :bad_request
+  end
+
   def payload
     @payload ||= request.body.read
   end


### PR DESCRIPTION
Adds a before_action :verify_event for our webhooks controllers so we can verify webhooks for each webhook provider in their associated controller.