### PR TITLE
Inherit from API Controller Instead

### DIFF
--- a/app/controllers/webhooks/base_controller.rb
+++ b/app/controllers/webhooks/base_controller.rb
@@ -1,4 +1,4 @@
-class Webhooks::BaseController < ApplicationController
+class Webhooks::BaseController < ActionController::API
   # Disable CSRF checking on webhooks because they do not originate from the browser
   skip_before_action :verify_authenticity_token
   

--- a/app/controllers/webhooks/base_controller.rb
+++ b/app/controllers/webhooks/base_controller.rb
@@ -1,7 +1,4 @@
 class Webhooks::BaseController < ActionController::API
-  # Disable CSRF checking on webhooks because they do not originate from the browser
-  skip_before_action :verify_authenticity_token
-  
   before_action :verify_event
 
   def create


### PR DESCRIPTION
> [API](https://api.rubyonrails.org/classes/ActionController/API.html) Controller is a lightweight version of [ActionController::Base](https://api.rubyonrails.org/classes/ActionController/Base.html), created for applications that don't require all functionalities that a complete Rails controller provides, allowing you to create controllers with just the features that you need for [API](https://api.rubyonrails.org/classes/ActionController/API.html) only applications.

This removes the need to skip CSRF checking and also should provide a small speed improvement.